### PR TITLE
Parameterize the kube-proxy bind address

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -14,6 +14,9 @@ kubelet_bind_address: "{{ ip | default('0.0.0.0') }}"
 # resolv.conf to base dns config
 kube_resolv_conf: "/etc/resolv.conf"
 
+# bind address for kube-proxy
+kube_proxy_bind_address: "{{ ip | default(ansible_default_ipv4.address) }}"
+
 # bind address for kube-proxy health check
 kube_proxy_healthz_bind_address: "127.0.0.1"
 

--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -41,7 +41,7 @@ spec:
     - proxy
     - --v={{ kube_log_level }}
     - --kubeconfig={{kube_config_dir}}/kube-proxy-kubeconfig.yaml
-    - --bind-address={{ ip | default(ansible_default_ipv4.address) }}
+    - --bind-address={{ kube_proxy_bind_address }}
     - --cluster-cidr={{ kube_pods_subnet }}
     - --proxy-mode={{ kube_proxy_mode }}
     - --oom-score-adj=-998


### PR DESCRIPTION
Updated the kube-proxy manifest template to use role defaults for
interface bindigng which allows over-ride for hosts having mutiple
interfaces.