### PR TITLE
Fix the dic iteration method in the kubelet template

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -84,7 +84,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}
-{%   for labelname, labelvalue in node_labels.iteritems() %}
+{%   for labelname, labelvalue in node_labels.items() %}
 {%     set dummy = inventory_node_labels.append('%s=%s'|format(labelname, labelvalue)) %}
 {%   endfor %}
 {% endif %}

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -102,7 +102,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}
-{%   for labelname, labelvalue in node_labels.iteritems() %}
+{%   for labelname, labelvalue in node_labels.items() %}
 {%     set dummy = inventory_node_labels.append('%s=%s'|format(labelname, labelvalue)) %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
Kubelet template rendering errors when additional Node lables are
added and using Python3. Update the method to be compatible to both
python2/3

Node lables doesn't work